### PR TITLE
INFRA-493: Compare dependency reports as part of the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,13 +268,16 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Compile a dependency report -->
+            <!-- Compile and compare the dependency report -->
             <plugin>
                 <groupId>net.mekomsolutions.maven.plugin</groupId>
                 <artifactId>dependency-tracker-maven-plugin</artifactId>
+                <configuration>
+                    <compare>true</compare>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>Compile dependency report</id>
+                        <id>Compile local dependency report and compare with remote</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>track</goal>


### PR DESCRIPTION
Set the Maven Dependency Tracker to do the comparison of the dependency reports so that CI only has to read the result of this comparison and publish or end.

https://mekomsolutions.atlassian.net/browse/INFRA-493
